### PR TITLE
#47 楽曲追加と楽曲一覧の夢ステ用対応

### DIFF
--- a/client/src/components/hooks/useMusicQuery.ts
+++ b/client/src/components/hooks/useMusicQuery.ts
@@ -18,8 +18,6 @@ export const fetchMusicList = async (page: number, isInfinityScroll: boolean, cu
     },
   });
 
-  console.log(response.data);
-
   return response.data;
 };
 

--- a/client/src/components/score/register/index.tsx
+++ b/client/src/components/score/register/index.tsx
@@ -162,19 +162,19 @@ const RegisterMusicScore = () => {
       const remainNoteCount = watchedTotalNoteCount - count;
       if (filledFields == 1) {
         watchedScores.forEach((score, idx) => {
-          if (isNaN(score) && idx == 0) {
+          if (Number.isNaN(score) && idx == 0) {
             setValue('perfectCount', remainNoteCount);
           }
-          if (isNaN(score) && idx == 1) {
+          if (Number.isNaN(score) && idx == 1) {
             setValue('greatCount', remainNoteCount);
           }
-          if (isNaN(score) && idx == 2) {
+          if (Number.isNaN(score) && idx == 2) {
             setValue('goodCount', remainNoteCount);
           }
-          if (isNaN(score) && idx == 3) {
+          if (Number.isNaN(score) && idx == 3) {
             setValue('badCount', remainNoteCount);
           }
-          if (isNaN(score) && idx == 4) {
+          if (Number.isNaN(score) && idx == 4) {
             setValue('missCount', remainNoteCount);
           }
         });
@@ -182,20 +182,19 @@ const RegisterMusicScore = () => {
       //フルコンボまたはAP用のスコア補完機能
       else if (remainNoteCount === 0) {
         watchedScores.forEach((score, idx) => {
-          console.log(score);
-          if (isNaN(score) && idx == 0) {
+          if (Number.isNaN(score) && idx == 0) {
             setValue('perfectCount', 0);
           }
-          if (isNaN(score) && idx == 1) {
+          if (Number.isNaN(score) && idx == 1) {
             setValue('greatCount', 0);
           }
-          if (isNaN(score) && idx == 2) {
+          if (Number.isNaN(score) && idx == 2) {
             setValue('goodCount', 0);
           }
-          if (isNaN(score) && idx == 3) {
+          if (Number.isNaN(score) && idx == 3) {
             setValue('badCount', 0);
           }
-          if (isNaN(score) && idx == 4) {
+          if (Number.isNaN(score) && idx == 4) {
             setValue('missCount', 0);
           }
         });
@@ -208,32 +207,32 @@ const RegisterMusicScore = () => {
         watchedGoodCount,
         watchedBadCount,
         watchedMissCount,
-      ]).filter((val) => isNaN(val)).length;
+      ]).filter((val) => Number.isNaN(val)).length;
       const count = watchedScores2.reduce((accumulator, currentValue) => {
         const numericValue = Number(currentValue);
-        return accumulator + (isNaN(numericValue) ? 0 : numericValue);
+        return (accumulator ?? 0) + (Number.isNaN(numericValue) ? 0 : numericValue);
       }, 0);
 
-      const remainNoteCount = watchedTotalNoteCount - count;
+      const remainNoteCount = watchedTotalNoteCount - (count ?? 0);
 
       if (filledFields == 1) {
         watchedScores2.forEach((score, idx) => {
-          if (isNaN(score ?? 0) && idx == 0) {
+          if (Number.isNaN(score) && idx == 0) {
             setValue('perfectPlusCount', remainNoteCount);
           }
-          if (isNaN(score ?? 0) && idx == 1) {
+          if (Number.isNaN(score) && idx == 1) {
             setValue('perfectCount', remainNoteCount);
           }
-          if (isNaN(score ?? 0) && idx == 2) {
+          if (Number.isNaN(score) && idx == 2) {
             setValue('greatCount', remainNoteCount);
           }
-          if (isNaN(score ?? 0) && idx == 3) {
+          if (Number.isNaN(score) && idx == 3) {
             setValue('goodCount', remainNoteCount);
           }
-          if (isNaN(score ?? 0) && idx == 4) {
+          if (Number.isNaN(score) && idx == 4) {
             setValue('badCount', remainNoteCount);
           }
-          if (isNaN(score ?? 0) && idx == 5) {
+          if (Number.isNaN(score) && idx == 5) {
             setValue('missCount', remainNoteCount);
           }
         });
@@ -241,22 +240,22 @@ const RegisterMusicScore = () => {
       //フルコンボまたはAP用のスコア補完機能
       else if (remainNoteCount === 0) {
         watchedScores2.forEach((score, idx) => {
-          if (isNaN(score ?? 0) && idx == 0) {
+          if (Number.isNaN(score) && idx == 0) {
             setValue('perfectPlusCount', 0);
           }
-          if (isNaN(score ?? 0) && idx == 1) {
+          if (Number.isNaN(score) && idx == 1) {
             setValue('perfectCount', 0);
           }
-          if (isNaN(score ?? 0) && idx == 2) {
+          if (Number.isNaN(score) && idx == 2) {
             setValue('greatCount', 0);
           }
-          if (isNaN(score ?? 0) && idx == 3) {
+          if (Number.isNaN(score) && idx == 3) {
             setValue('goodCount', 0);
           }
-          if (isNaN(score ?? 0) && idx == 4) {
+          if (Number.isNaN(score) && idx == 4) {
             setValue('badCount', 0);
           }
-          if (isNaN(score ?? 0) && idx == 5) {
+          if (Number.isNaN(score) && idx == 5) {
             setValue('missCount', 0);
           }
         });

--- a/client/src/components/score/register/index.tsx
+++ b/client/src/components/score/register/index.tsx
@@ -18,11 +18,17 @@ const RegisterMusicScore = () => {
   const [selectedMusic, setSelectedMusic] = useState<MusicType | null>(null);
   const [registerConsecutively, setRegisterConsecutively] = useState<boolean>(true);
   const { currentGenre } = useGenre();
+  const [difficultyList, setDifficultyList] = useState<string[]>([]);
+  const [musicList, setMusicList] = useState<MusicType[]>([]);
 
   const schema = z
     .object({
       musicId: z.number({ message: '曲を選択してください' }).min(1, '曲を選択してください'),
       musicDifficulty: z.string().nonempty(),
+      perfectPlusCount:
+        currentGenre === 2
+          ? z.number({ message: 'PerfectPlusは数値を入力してください' }).min(0, '無効な数値です')
+          : z.number().optional(),
       perfectCount: z.number({ message: 'Perfectは数値を入力してください' }).min(0, '無効な数値です'),
       greatCount: z.number({ message: 'Greatは数値を入力してください' }).min(0, '無効な数値です'),
       goodCount: z.number({ message: 'Goodは数値を入力してください' }).min(0, '無効な数値です'),
@@ -31,8 +37,24 @@ const RegisterMusicScore = () => {
       totalNoteCount: z.number({ message: '曲を選択するか、難易度を変更してください' }),
     })
     .refine(
-      (data) =>
-        data.totalNoteCount === data.perfectCount + data.greatCount + data.goodCount + data.badCount + data.missCount,
+      (data) => {
+        if (currentGenre === 2 && data.perfectPlusCount) {
+          return (
+            data.totalNoteCount ===
+            data.perfectPlusCount +
+              data.perfectCount +
+              data.greatCount +
+              data.goodCount +
+              data.badCount +
+              data.missCount
+          );
+        } else {
+          return (
+            data.totalNoteCount ===
+            data.perfectCount + data.greatCount + data.goodCount + data.badCount + data.missCount
+          );
+        }
+      },
       {
         message: '総ノーツ数と数が合っていません',
         path: ['totalNoteCount'],
@@ -71,15 +93,16 @@ const RegisterMusicScore = () => {
 
   useEffect(() => {
     getAllMusic();
-  }, []);
+    setMusicDifficulty();
+  }, [currentGenre]);
 
-  const [musicList, setMusicList] = useState<MusicType[]>([]);
-
-  const [difficultyList] = useState(
-    currentGenre == 1
-      ? ['easy', 'normal', 'hard', 'expert', 'master', 'append']
-      : ['easy', 'normal', 'extra', 'stella', 'olivier'],
-  );
+  const setMusicDifficulty = () => {
+    if (currentGenre === 1) {
+      setDifficultyList(['easy', 'normal', 'hard', 'expert', 'master', 'append']);
+    } else if (currentGenre === 2) {
+      setDifficultyList(['easy', 'normal', 'hard', 'extra', 'stella', 'olivier']);
+    }
+  };
 
   const watchMusic = watch(['musicId', 'musicDifficulty']);
 
@@ -105,6 +128,15 @@ const RegisterMusicScore = () => {
   }, [watchMusic, musicList, setValue]);
 
   const watchedScores = getValues(['perfectCount', 'greatCount', 'goodCount', 'badCount', 'missCount']);
+  const watchedScores2 = getValues([
+    'perfectPlusCount',
+    'perfectCount',
+    'greatCount',
+    'goodCount',
+    'badCount',
+    'missCount',
+  ]);
+  const watchedPerfectPlusCount = watch('perfectPlusCount');
   const watchedPerfectCount = watch('perfectCount');
   const watchedGreatCount = watch('greatCount');
   const watchedGoodCount = watch('goodCount');
@@ -114,58 +146,121 @@ const RegisterMusicScore = () => {
 
   //テキストフィールドからフォーカスが外れた際にスコア補完機能が働く
   const onBlurScoreCompletion = () => {
-    const filledFields = Object.values([
-      watchedPerfectCount,
-      watchedGreatCount,
-      watchedGoodCount,
-      watchedBadCount,
-      watchedMissCount,
-    ]).filter((val) => isNaN(val)).length;
-    const count = watchedScores.reduce((accumulator, currentValue) => {
-      const numericValue = Number(currentValue);
-      return accumulator + (isNaN(numericValue) ? 0 : numericValue);
-    }, 0);
+    if (currentGenre === 1) {
+      const filledFields = Object.values([
+        watchedPerfectCount,
+        watchedGreatCount,
+        watchedGoodCount,
+        watchedBadCount,
+        watchedMissCount,
+      ]).filter((val) => isNaN(val)).length;
+      const count = watchedScores.reduce((accumulator, currentValue) => {
+        const numericValue = Number(currentValue);
+        return accumulator + (isNaN(numericValue) ? 0 : numericValue);
+      }, 0);
 
-    //TODO:: やり直しする際に不便
-    const remainNoteCount = watchedTotalNoteCount - count;
-    if (filledFields == 1) {
-      watchedScores.forEach((score, idx) => {
-        if (isNaN(score) && idx == 0) {
-          setValue('perfectCount', remainNoteCount);
-        }
-        if (isNaN(score) && idx == 1) {
-          setValue('greatCount', remainNoteCount);
-        }
-        if (isNaN(score) && idx == 2) {
-          setValue('goodCount', remainNoteCount);
-        }
-        if (isNaN(score) && idx == 3) {
-          setValue('badCount', remainNoteCount);
-        }
-        if (isNaN(score) && idx == 4) {
-          setValue('missCount', remainNoteCount);
-        }
-      });
-    }
-    //フルコンボまたはAP用のスコア補完機能
-    else if (remainNoteCount === 0) {
-      watchedScores.forEach((score, idx) => {
-        if (isNaN(score) && idx == 0) {
-          setValue('perfectCount', 0);
-        }
-        if (isNaN(score) && idx == 1) {
-          setValue('greatCount', 0);
-        }
-        if (isNaN(score) && idx == 2) {
-          setValue('goodCount', 0);
-        }
-        if (isNaN(score) && idx == 3) {
-          setValue('badCount', 0);
-        }
-        if (isNaN(score) && idx == 4) {
-          setValue('missCount', 0);
-        }
-      });
+      const remainNoteCount = watchedTotalNoteCount - count;
+      if (filledFields == 1) {
+        watchedScores.forEach((score, idx) => {
+          if (isNaN(score) && idx == 0) {
+            setValue('perfectCount', remainNoteCount);
+          }
+          if (isNaN(score) && idx == 1) {
+            setValue('greatCount', remainNoteCount);
+          }
+          if (isNaN(score) && idx == 2) {
+            setValue('goodCount', remainNoteCount);
+          }
+          if (isNaN(score) && idx == 3) {
+            setValue('badCount', remainNoteCount);
+          }
+          if (isNaN(score) && idx == 4) {
+            setValue('missCount', remainNoteCount);
+          }
+        });
+      }
+      //フルコンボまたはAP用のスコア補完機能
+      else if (remainNoteCount === 0) {
+        watchedScores.forEach((score, idx) => {
+          console.log(score);
+          if (isNaN(score) && idx == 0) {
+            setValue('perfectCount', 0);
+          }
+          if (isNaN(score) && idx == 1) {
+            setValue('greatCount', 0);
+          }
+          if (isNaN(score) && idx == 2) {
+            setValue('goodCount', 0);
+          }
+          if (isNaN(score) && idx == 3) {
+            setValue('badCount', 0);
+          }
+          if (isNaN(score) && idx == 4) {
+            setValue('missCount', 0);
+          }
+        });
+      }
+    } else if (currentGenre === 2) {
+      const filledFields = Object.values([
+        watchedPerfectPlusCount,
+        watchedPerfectCount,
+        watchedGreatCount,
+        watchedGoodCount,
+        watchedBadCount,
+        watchedMissCount,
+      ]).filter((val) => isNaN(val)).length;
+      const count = watchedScores2.reduce((accumulator, currentValue) => {
+        const numericValue = Number(currentValue);
+        return accumulator + (isNaN(numericValue) ? 0 : numericValue);
+      }, 0);
+
+      const remainNoteCount = watchedTotalNoteCount - count;
+
+      if (filledFields == 1) {
+        watchedScores2.forEach((score, idx) => {
+          if (isNaN(score ?? 0) && idx == 0) {
+            setValue('perfectPlusCount', remainNoteCount);
+          }
+          if (isNaN(score ?? 0) && idx == 1) {
+            setValue('perfectCount', remainNoteCount);
+          }
+          if (isNaN(score ?? 0) && idx == 2) {
+            setValue('greatCount', remainNoteCount);
+          }
+          if (isNaN(score ?? 0) && idx == 3) {
+            setValue('goodCount', remainNoteCount);
+          }
+          if (isNaN(score ?? 0) && idx == 4) {
+            setValue('badCount', remainNoteCount);
+          }
+          if (isNaN(score ?? 0) && idx == 5) {
+            setValue('missCount', remainNoteCount);
+          }
+        });
+      }
+      //フルコンボまたはAP用のスコア補完機能
+      else if (remainNoteCount === 0) {
+        watchedScores2.forEach((score, idx) => {
+          if (isNaN(score ?? 0) && idx == 0) {
+            setValue('perfectPlusCount', 0);
+          }
+          if (isNaN(score ?? 0) && idx == 1) {
+            setValue('perfectCount', 0);
+          }
+          if (isNaN(score ?? 0) && idx == 2) {
+            setValue('greatCount', 0);
+          }
+          if (isNaN(score ?? 0) && idx == 3) {
+            setValue('goodCount', 0);
+          }
+          if (isNaN(score ?? 0) && idx == 4) {
+            setValue('badCount', 0);
+          }
+          if (isNaN(score ?? 0) && idx == 5) {
+            setValue('missCount', 0);
+          }
+        });
+      }
     }
   };
 
@@ -192,6 +287,7 @@ const RegisterMusicScore = () => {
       reset({
         musicId: registerConsecutively ? values.musicId : 0,
         totalNoteCount: registerConsecutively ? values.totalNoteCount : NaN,
+        perfectPlusCount: NaN,
         perfectCount: NaN,
         greatCount: NaN,
         goodCount: NaN,
@@ -244,6 +340,21 @@ const RegisterMusicScore = () => {
               disabled
               className='mb-4 p-2 rounded border border-gray-300 w-full'
             />
+            {currentGenre === 2 && (
+              <>
+                <input
+                  {...register('perfectPlusCount', { required: true, valueAsNumber: true })}
+                  type='number'
+                  placeholder='PerfectPlus'
+                  min={0}
+                  onBlur={onBlurScoreCompletion}
+                  className='mb-4 p-2 rounded border border-gray-300 w-full'
+                />
+                {errors.perfectPlusCount && (
+                  <span className='text-red-500 mb-2 block'>{errors.perfectPlusCount.message}</span>
+                )}
+              </>
+            )}
             <input
               {...register('perfectCount', { required: true, valueAsNumber: true })}
               type='number'

--- a/client/src/components/score/view/index.tsx
+++ b/client/src/components/score/view/index.tsx
@@ -14,7 +14,7 @@ const ScoresList = () => {
   const { currentGenre } = useGenre();
   useEffect(() => {
     getScoreList();
-  }, []);
+  }, [currentGenre]);
   async function getScoreList() {
     try {
       const response = await axiosClient.get(`${import.meta.env.VITE_APP_URL}scores/list`, {
@@ -86,11 +86,20 @@ const ScoresList = () => {
                         day: '2-digit',
                       })}
                     </p>
+
                     <div className='flex flex-col'>
                       <div className='flex justify-between mb-1'>
                         <span className='font-semibold'>TotalNoteCount</span>
                         <span>{score.totalNoteCount}</span>
                       </div>
+                      {currentGenre === 2 && (
+                        <>
+                          <div className='flex justify-between mb-1'>
+                            <span className='font-semibold'>PerfectPlus:</span>
+                            <span>{score.perfectPlusCount || 0}</span>
+                          </div>
+                        </>
+                      )}
                       <div className='flex justify-between mb-1'>
                         <span className='font-semibold'>Perfect:</span>
                         <span>{score.perfectCount}</span>

--- a/client/src/types/score/index.ts
+++ b/client/src/types/score/index.ts
@@ -1,5 +1,6 @@
 export type ScoreType = {
   totalNoteCount: number;
+  perfectPlusCount?: number;
   perfectCount: number;
   greatCount: number;
   goodCount: number;

--- a/server/src/scores/scores.service.ts
+++ b/server/src/scores/scores.service.ts
@@ -135,6 +135,7 @@ export class ScoresService {
         musicId: post.musicId,
         genreId: post.genreId,
         totalNoteCount: metaMusic.totalNoteCount,
+        perfectPlusCount: post.perfectPlusCount,
         perfectCount: post.perfectCount,
         greatCount: post.greatCount,
         goodCount: post.goodCount,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - `RegisterMusicScore`コンポーネントにおいて、`perfectPlusCount`の入力フィールドと関連するバリデーションを追加しました。

- **バグ修正**
  - `fetchMusicList`関数のコンソールログを削除しました。

- **改良**
  - `ScoresList`コンポーネントで`currentGenre`の変更によりスコアリストを再取得するように修正しました。
  - `ScoreType`に`perfectPlusCount`フィールドを追加しました。
  - `ScoresService`に`perfectPlusCount`プロパティを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->