### PR TITLE
#114 楽曲一覧でキャッシュを使用しないように変更

### DIFF
--- a/server/src/songs/songs.service.ts
+++ b/server/src/songs/songs.service.ts
@@ -254,8 +254,9 @@ export class SongsService {
     if (isInfinityScroll) {
       skipAmount = query.page * pageSize;
     }
+
     const cacheKey = 'cache-' + genreId;
-    if (!query.title) {
+    if (!query.title && !isInfinityScroll) {
       const cachedMusic: Music = await this.cacheManager.get(cacheKey);
       if (cachedMusic) {
         console.log('キャッシュを利用します');
@@ -316,7 +317,10 @@ export class SongsService {
         // },
       },
     });
-    await this.cacheManager.set(cacheKey, searchedMusicList, 20000);
+
+    if (!isInfinityScroll) {
+      await this.cacheManager.set(cacheKey, searchedMusicList, 20000);
+    }
 
     if (page === 0) {
       const unitProfile = await this.metaMusicService.getUnitProfile();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 無限スクロールの条件に基づいてキャッシュのロジックを改良しました。これにより、無限スクロール中はキャッシュが利用されず、最新のデータが表示されるようになります。
  
- **バグ修正**
  - キャッシュの更新条件を調整し、無限スクロールがアクティブな場合に古いデータがキャッシュされることを防ぎます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->